### PR TITLE
Python3 Port of couchable

### DIFF
--- a/couchable/__init__.py
+++ b/couchable/__init__.py
@@ -24,7 +24,7 @@ The public API of couchable consists of:
     - L{packer}: Extends the list of built-in or C types supported.
     - L{registerDocType}, L{CouchableDoc}: For adding new document classes.
     - L{registerAttachmentType}, L{CouchableAttachment}: For adding classes to store as attachments.
-    - L{gzip_compress}, L{gzip_decompress}: Helper functions for compressing attachments.
+    - L{doGzip}, L{doGunzip}: Helper functions for compressing attachments.
     - L{newid}: Helper function to make document IDs readable.
 
 For more information, please see:
@@ -46,5 +46,5 @@ from .core import registerDocType, CouchableDoc
 from .core import registerAttachmentType, CouchableAttachment
 from .core import registerPickleType, registerNoneType, registerUncouchableType
 from .core import custom_packer
-from .core import gzip_compress, gzip_decompress
+from .core import doGzip, doGunzip
 from .core import newid

--- a/couchable/__init__.py
+++ b/couchable/__init__.py
@@ -24,7 +24,7 @@ The public API of couchable consists of:
     - L{packer}: Extends the list of built-in or C types supported.
     - L{registerDocType}, L{CouchableDoc}: For adding new document classes.
     - L{registerAttachmentType}, L{CouchableAttachment}: For adding classes to store as attachments.
-    - L{doGzip}, L{doGunzip}: Helper functions for compressing attachments.
+    - L{gzip_compress}, L{gzip_decompress}: Helper functions for compressing attachments.
     - L{newid}: Helper function to make document IDs readable.
 
 For more information, please see:
@@ -41,10 +41,10 @@ From the README.txt:
 --README.txt--
 """
 
-from core import CouchableDb
-from core import registerDocType, CouchableDoc
-from core import registerAttachmentType, CouchableAttachment
-from core import registerPickleType, registerNoneType, registerUncouchableType
-from core import custom_packer
-from core import doGzip, doGunzip
-from core import newid
+from .core import CouchableDb
+from .core import registerDocType, CouchableDoc
+from .core import registerAttachmentType, CouchableAttachment
+from .core import registerPickleType, registerNoneType, registerUncouchableType
+from .core import custom_packer
+from .core import gzip_compress, gzip_decompress
+from .core import newid

--- a/couchable/core.py
+++ b/couchable/core.py
@@ -18,8 +18,53 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-# logging
+# Future compatibility
+from __future__ import division, absolute_import, print_function, unicode_literals
+
+# Stdlib
+import base64
+import collections
+import copy
+import gzip
+import hashlib
+import inspect
+import io
 import logging
+import math
+import os
+import pprint
+import random
+import string
+import sys
+import time
+import uuid
+import weakref
+
+# External dependencies
+import couchdb
+import couchdb.client
+import couchdb.design
+import couchdb.http
+import couchdb.json
+import couchdb.multipart
+import requests
+
+# Compatibility imports
+if sys.version_info.major < 3:
+    import cPickle as pickle
+    import __builtin__ as builtins
+    binary_type = str
+    integer_types = (int, long)
+    string_types = basestring,
+    from itertools import izip as zip
+else:
+    import pickle
+    import builtins
+    binary_type = bytes
+    integer_types = int,
+    string_types = str,
+
+
 log_api = logging.getLogger(__name__.replace('core', 'api'))
 log_api.setLevel(logging.WARN)
 
@@ -27,46 +72,10 @@ log_internal = logging.getLogger(__name__.replace('core', 'internal'))
 log_internal.setLevel(logging.WARN)
 
 
-"""
-foo
-"""
-import base64
-import collections
-import copy
-import cPickle as pickle
-import cStringIO
-import datetime
-import gzip
-import hashlib
-import inspect
-import itertools
-import os
-import pprint
-import random
-import re
-import string
-import subprocess
-import sys
-import tempfile
-import time
-import traceback
-import uuid
-import weakref
-
-#import yaml
-import couchdb
-import couchdb.client
-import couchdb.design
-import couchdb.http
-import couchdb.json
-import couchdb.multipart
-
-import requests
-
 def importstr(module_str, from_=None):
     """
     >>> importstr('os')
-    <module 'os' from '.../os.pyc'>
+    <module 'os' from '...os.py'>
     >>> importstr('math', 'fabs')
     <built-in function fabs>
     """
@@ -78,10 +87,11 @@ def importstr(module_str, from_=None):
         return getattr(module, from_)
     return module
 
+
 def typestr(type_):
     if not isinstance(type_, type):
         type_ = type(type_)
-    if type_.__name__ in __builtins__:
+    if hasattr(builtins, type_.__name__) or type_ == type(None):
         return type_.__name__
     else:
         return '{}.{}'.format(type_.__module__, type_.__name__)
@@ -163,7 +173,7 @@ def findHandler(cls_or_name, handler_dict):
     if (cls_or_name,) in handler_dict:
         return handler_dict[(cls_or_name,)]
     elif isinstance(cls_or_name, type):
-        for type_, handler in reversed(handler_dict.items()):
+        for type_, handler in reversed(list(handler_dict.items())):
             if isinstance(type_, type) and issubclass(cls_or_name, type_):
                 handler_dict[(cls_or_name,)] = type_, handler
                 return type_, handler
@@ -191,8 +201,6 @@ class CouchableDb(object):
         Creates a CouchableDb wrapper around a couchdb.Database object.  If
         the database does not yet exist, it will be created.
 
-        @type  name: str
-        @param name: Name of the CouchDB database to connect to.
         @type  url: str
         @param url: The URL of the CouchDB server.  Uses the couchdb default of http://localhost:5984/
         @type  db: couchdb.Database
@@ -201,6 +209,11 @@ class CouchableDb(object):
 
         self._db_pid = None
         self._db = None
+        self._done_dict = collections.OrderedDict()
+        self._cycle_set = set()
+        self._additiveOnly = None
+        self._skip_list = []
+
 
         if db is not None:
             assert url is None
@@ -223,6 +236,7 @@ class CouchableDb(object):
             if requests.head(self.url).status_code != 200:
                 put_dict = requests.put(self.url).json()
                 if 'ok' not in put_dict:
+                    # FIXME: Make custom Exception
                     raise Exception("Could not create DB: {!r}".format(put_dict))
 
 
@@ -426,7 +440,7 @@ class CouchableDb(object):
                 if 'pickles' in attachment_dict:
                     content_tup = attachment_dict['pickles']
 
-                    content = doGzip(doPickle(content_tup))
+                    content = gzip_compress(pickle_object(content_tup))
                     content_type = 'application/pickle'
 
                     attachment_dict['pickles'] = (content, content_type)
@@ -439,7 +453,7 @@ class CouchableDb(object):
                 if total_len > self._maxStrLen * 2:
                     mime_list.append((obj, doc, attachment_dict, total_len))
                 else:
-                    doc['_attachments'] = {content_name: {'content_type': content_type, 'data': base64.b64encode(content)} for content_name, (content, content_type) in attachment_dict.items()}
+                    doc['_attachments'] = {content_name: {'content_type': content_type, 'data': base64.b64encode(content).decode("UTF-8")} for content_name, (content, content_type) in attachment_dict.items()}
                     bulk_list.append((obj, doc))
 
         #print 'mime', mime_list
@@ -454,7 +468,7 @@ class CouchableDb(object):
                 obj._rev = doc['_rev']
                 obj._couchableMultipartPending = True
 
-            fileobj = cStringIO.StringIO()
+            fileobj = io.StringIO()
 
             with couchdb.multipart.MultipartWriter(fileobj, headers=None, subtype='form-data') as mpw:
                 mime_headers = {'Content-Disposition': '''form-data; name="_doc"'''}
@@ -478,15 +492,15 @@ class CouchableDb(object):
             status, msg, data = self.db.resource.post(doc['_id'], body, http_headers, **params)
 
             if status != 201:
-                log_internal.warn("Error updating multipart, status: {}, msg: {}".format(staus, msg))
-                raise Exception("Error updating multipart, status: {}, msg: {}".format(staus, msg))
+                log_internal.warning("Error updating multipart, status: {}, msg: {}".format(status, msg))
+                # FIXME: Make custom Exception
+                raise Exception("Error updating multipart, status: {}, msg: {}".format(status, msg))
                 #print 'status', status
                 #print 'msg', msg
                 #print 'data', str(data.getvalue())
                 #assert status == 201
 
             data_dict = couchdb.json.decode(data.getvalue())
-
             #print data_dict
 
             obj._id = data_dict['id']
@@ -499,16 +513,16 @@ class CouchableDb(object):
         #print 'hitting bulk docs:', [x for x in [str(bulk_tup[1].get('_id', None)) for bulk_tup in bulk_list] if 'CoordinateSystem' not in x]
         try:
             ret_list = self.db.update([bulk_tup[1] for bulk_tup in bulk_list])
-        except UnicodeDecodeError as e:
+        except UnicodeDecodeError:
             for bulk_obj, bulk_doc in bulk_list:
                 for s in findBadJson(bulk_doc, bulk_obj._id):
                     log_api.error("Bad json: {}".format(s))
             raise
 
         #print ret_list
-        for (success, _id, _rev), (obj, doc) in itertools.izip(ret_list, bulk_list):
+        for (success, _id, _rev), (obj, doc) in zip(ret_list, bulk_list):
             if not success:
-                log_internal.warn("Error updating {}: {} @ {}".format(type(obj), _id, getattr(obj, '_rev', None)))
+                log_internal.warning("Error updating {}: {} @ {}".format(type(obj), _id, getattr(obj, '_rev', None)))
                 #log_internal.warn("Error updating {}: {} > {}".format(type(obj), _id, vars(_rev)))
                 raise _rev
             else:
@@ -519,10 +533,10 @@ class CouchableDb(object):
         #log_internal.error("outside for")
         #print "outside for", self._obj_by_id.items(), store_list
 
-        del self._done_dict
-        del self._cycle_set
-        del self._skip_list
-        del self._additiveOnly
+        self._done_dict = collections.OrderedDict()
+        self._cycle_set = set()
+        self._additiveOnly = None
+        self._skip_list = []
 
         if not isinstance(what, list):
             return what._id
@@ -577,7 +591,7 @@ class CouchableDb(object):
         #except RuntimeError:
         #    log_internal.error(name)
         #    raise
-        except Exception, e:
+        except Exception as exc:
             log_internal.error('{}, {} in base_cls {}, handler {} isKey: {}'.format(name, cls, base_cls, handler, isKey))
             raise
         #finally:
@@ -608,7 +622,10 @@ class CouchableDb(object):
         >>> cdb=CouchableDb('testing')
         >>> obj = object()
         >>> pprint.pprint(cdb._objInfo_doc(obj, {}))
-        {'couchable:': {'class': 'object', 'module': '__builtin__', 'pid': ..., 'time': ...}}
+        {'couchable:': {'class': 'object',
+                        'module': '...builtin...',
+                        'pid': ...,
+                        'time': ...}}
         """
         cls = type(data)
         doc.setdefault(FIELD_NAME, {})
@@ -637,7 +654,7 @@ class CouchableDb(object):
         {'couchable:': {'args': [1, 2, 3],
                         'class': 'tuple',
                         'kwargs': {},
-                        'module': '__builtin__',
+                        'module': '...builtin...',
                         'pid': ...,
                         'time': ...}
         """
@@ -760,14 +777,14 @@ class CouchableDb(object):
                 return '{}{}:{}'.format(FIELD_NAME, 'module', name)
 
 
-    @_packer(str, unicode)
+    @_packer(binary_type, *string_types)
     def _pack_native(self, parent_doc, data, attachment_dict, name, isKey):
         """
         >>> cdb=CouchableDb('testing')
         >>> parent_doc = {}
         >>> attachment_dict = {}
 
-        >>> data = 'byte string'
+        >>> data = b'byte string'
         >>> cdb._pack_native(parent_doc, data, attachment_dict, 'myname', False)
         'byte string'
         >>> cdb._pack_native(parent_doc, data, attachment_dict, 'myname', True)
@@ -783,23 +800,20 @@ class CouchableDb(object):
         >>> cdb._pack_native(parent_doc, data, attachment_dict, 'myname', False)
         'couchable:append:str:couchable:must escape this'
         """
-        #log_internal.debug("{}: {} @ {}, {}".format(type(data), getattr(data, '_id', None), getattr(data, '_rev', None), name))
-        #if len(data) > 1024:
-        #    return self._pack_attachment(parent_doc, data, attachment_dict, name, isKey)
+        pickle_binary = False
+        if isinstance(data, binary_type):
+            # Try out three most popular encodings, otherwise default to pickle
+            for codec in ["UTF-8", "UTF-16", "Latin-1"]:
+                try:
+                    data = data.decode(codec)
+                    break
+                except UnicodeDecodeError:
+                    continue
+            else:
+                log_internal.warning("Could not decode binary string, pickle object")
+                pickle_binary = True
 
-        highBytes = False
-
-        if isinstance(data, str):
-            try:
-                data.decode('utf8')
-                # This means that it's either clean ascii, or encoded as utf8,
-                # as god intended.  We can work with it.
-            except:
-                # Otherwise it's latin1 or binary or who knows what.  Pickles.
-                #print "Found some high bytes:", data.encode('hex_codec')
-                highBytes = True
-
-        if '\0' in data or highBytes or len(data) > self._maxStrLen:
+        if '\0' in data or pickle_binary or len(data) > self._maxStrLen:
             #return '{}{}:{}:{}'.format(FIELD_NAME, 'repr', typestr(data), data.encode('hex_codec'))
             return self._pack_pickle(parent_doc, data, attachment_dict, name, isKey)
 
@@ -808,7 +822,7 @@ class CouchableDb(object):
         else:
             return data
 
-    @_packer(int, long, float, type(None))
+    @_packer(float, type(None), *integer_types)
     def _pack_native_keyAsRepr(self, parent_doc, data, attachment_dict, name, isKey):
         """
         >>> cdb=CouchableDb('testing')
@@ -824,6 +838,11 @@ class CouchableDb(object):
         12.34
         >>> cdb._pack_native_keyAsRepr(parent_doc, data, attachment_dict, 'myname', True)
         'couchable:repr:float:12.34'
+        >>> data = None
+        >>> cdb._pack_native_keyAsRepr(parent_doc, data, attachment_dict, 'myname', False) is None
+        True
+        >>> cdb._pack_native_keyAsRepr(parent_doc, data, attachment_dict, 'myname', True)
+        'couchable:repr:builtins.NoneType:None'
         """
         #log_internal.debug("{}: {} @ {}, {}".format(type(data), getattr(data, '_id', None), getattr(data, '_rev', None), name))
         if isKey:
@@ -983,7 +1002,7 @@ class CouchableDb(object):
 
         doc = {}
         for k,v in data.items():
-            if k not in private_keys and k not in set(['_attachments', '_cdb', '_couchableMultipartPending']):
+            if k not in private_keys and k not in {'_attachments', '_cdb', '_couchableMultipartPending'}:
                 if isObjDict:
                     k_str = str(k)
                 else:
@@ -1049,7 +1068,10 @@ class CouchableDb(object):
 
     def _unpack(self, parent_doc, doc, loaded_dict, inst=None):
         try:
-            if isinstance(doc, (str, unicode)):
+            if isinstance(doc, bytes):
+                # JSON Documents should be unicode encoded by standard
+                doc = doc.decode("UTF-8")
+            if isinstance(doc, str):
                 if doc.startswith(FIELD_NAME):
                     _, method_str, data = doc.split(':', 2)
 
@@ -1062,26 +1084,26 @@ class CouchableDb(object):
                     elif method_str == 'pickle':
                         if 'pickles' not in parent_doc[FIELD_NAME]:
                             attachment_response = self.db.get_attachment(parent_doc, 'pickles')
-                            parent_doc[FIELD_NAME]['pickles'] = pickle.loads(doGunzip(attachment_response.read()))
+                            parent_doc[FIELD_NAME]['pickles'] = unpickle_object(
+                                gzip_decompress(attachment_response.read())
+                            )
                             #parent_doc[FIELD_NAME]['pickles'] = collections.defaultdict(int)
 
                         return parent_doc[FIELD_NAME]['pickles'][data]
 
                     type_str, data = data.split(':', 1)
                     if method_str == 'append':
-                        if type_str == 'unicode':
-                            if isinstance(data, unicode):
-                                return data
+                        if type_str in ('unicode', "str"):
+                            if isinstance(data, bytes):
+                                return data.decode("UTF-8")
                             else:
-                                return unicode(data, 'utf8')
-                        if type_str == 'str':
-                            return str(data)
+                                return data
 
                     elif method_str == 'repr':
-                        if type_str in __builtins__:
-                            return __builtins__.get(type_str)(data)
-                        elif type_str == '__builtin__.NoneType':
+                        if type_str == 'NoneType':
                             return None
+                        elif hasattr(builtins, type_str):
+                            return getattr(builtins, type_str)(data)
                         else:
                             return importstr(*type_str.rsplit('.', 1))(data)
 
@@ -1110,7 +1132,7 @@ class CouchableDb(object):
                 else:
                     return doc
 
-            elif isinstance(doc, (int, float)):
+            elif isinstance(doc, integer_types + (float,)):
                 return doc
 
             elif isinstance(doc, list):
@@ -1209,7 +1231,7 @@ class CouchableDb(object):
             loaded_dict = {(x.id if isinstance(x, couchdb.client.Row) else x['_id']): (x.doc if isinstance(x, couchdb.client.Row) else x) for x in loaded}
         elif isinstance(loaded, dict):
             loaded_dict = loaded
-        elif loaded == None:
+        elif loaded is None:
             loaded_dict = {}
         else:
             raise TypeError("'loaded' must be list, dict, or not specified.")
@@ -1228,7 +1250,7 @@ class CouchableDb(object):
 
         for item in load_list:
             #print "item", item
-            if isinstance(item, basestring):
+            if isinstance(item, string_types):
                 id_list.append(item)
             elif isinstance(item, couchdb.client.Row):
                 id_list.append(item.id)
@@ -1244,6 +1266,7 @@ class CouchableDb(object):
             elif hasattr(item, '_id'):
                 id_list.append(item._id)
             else:
+                # FIXME: Make custom Exception
                 raise Exception("Can't figure out how to load {!r}".format(item))
 
         # FIXME: pre-stuff the loaded_dict cache here
@@ -1410,8 +1433,29 @@ def newid(obj, id_func=None, noUuid=False, noType=False, sep=':'):
         obj._id = sep.join(id_list).lstrip('_')
         log_internal.debug("Assigning _id {} to {}".format(obj._id, obj))
 
-# Attachments
-def doGzip(data, compresslevel=1):
+
+def zlib_buffer_fixed():
+    """Helper function to check whether chunking is necessary
+
+    Chunking is due to needing to work on: < 2.7.14, 3.5.3
+     - Issue #27130: In the "zlib" module, fix handling of large buffers
+      (typically 2 or 4 GiB).  Previously, inputs were limited to 2 GiB, and
+      compression and decompression operations did not properly handle results of
+      2 or 4 GiB.
+      Fixed in: 2.7.14, 3.5.3
+    """
+    if sys.version_info.major == 2:
+        if sys.version_info < (2, 7, 14):
+            return False
+        else:
+            return True
+    elif sys.version_info < (3, 5, 3):
+        return False
+    else:
+        return True
+
+
+def gzip_compress(data, compresslevel=1):
     """
     Helper function for compressing byte strings.
 
@@ -1421,25 +1465,36 @@ def doGzip(data, compresslevel=1):
       compression and decompression operations did not properly handle results of
       2 or 4 GiB.
 
+    Fixed in: 2.7.14, 3.5.3
+
     @type  data: byte string
     @param data: The data to compress.
     @rtype: byte string
     @return: The compressed byte string.
     """
-    log_internal.debug("data len {}".format(len(data)))
+    if isinstance(data, str):
+        data = data.encode("UTF-8")
+    elif not isinstance(data, bytes):
+        data = str(data).encode("UTF-8")
+    log_internal.debug("Compress byte string with length: {}".format(len(data)))
 
-    str_io = cStringIO.StringIO()
-    gz_file = gzip.GzipFile(mode='wb', compresslevel=1, fileobj=str_io)
+    buffer = io.BytesIO()
+    gz_file = gzip.GzipFile(mode='wb', compresslevel=compresslevel, fileobj=buffer)
+    try:
+        if zlib_buffer_fixed():
+            gz_file.write(data)
+        else:
+            for offset in range(0, len(data), 2**30):
+                gz_file.write(data[offset:offset+2**30])
+    finally:
+        gz_file.close()
 
-    for offset in range(0, len(data), 2**30):
-        gz_file.write(data[offset:offset+2**30])
-    gz_file.close()
+    return buffer.getvalue()
 
-    return str_io.getvalue()
 
-def doGunzip(data):
+def gzip_decompress(data):
     """
-    Helper function for compressing byte strings.
+    Helper function for decompressing byte strings.
 
     Chunking is due to needing to work on pythons < 2.7.13:
     - Issue #27130: In the "zlib" module, fix handling of large buffers
@@ -1452,35 +1507,43 @@ def doGunzip(data):
     @rtype: byte string
     @return: The uncompressed byte string.
     """
-    log_internal.debug("data len {}".format(len(data)))
+    log_internal.debug("Decompress byte string with length: {}".format(len(data)))
 
-    str_io = cStringIO.StringIO(data)
-    gz_file = gzip.GzipFile(mode='rb', fileobj=str_io)
-    read_csio = cStringIO.StringIO()
+    data_buffer = io.BytesIO(data)
+    gz_file = gzip.GzipFile(mode='rb', fileobj=data_buffer)
 
-    while True:
-        uncompressed_data = gz_file.read(2**30)
-        if uncompressed_data:
-            read_csio.write(uncompressed_data)
+    try:
+        if zlib_buffer_fixed():
+            read_buffer = io.BytesIO(gz_file.read())
         else:
-            break
+            read_buffer = io.BytesIO()
+            while True:
+                uncompressed_data = gz_file.read(2**30)
+                if uncompressed_data:
+                    read_buffer.write(uncompressed_data)
+                else:
+                    break
+    finally:
+        gz_file.close()
 
-    return read_csio.getvalue()
+    return read_buffer.getvalue()
 
-def doPickle(obj):
-    log_internal.debug("obj {}".format(type(obj)))
+
+def pickle_object(obj):
+    log_internal.debug("Pickle object of type: {}".format(type(obj)))
     return pickle.dumps(obj, pickle.HIGHEST_PROTOCOL)
 
-def doUnpickle(data):
-    log_internal.debug("data len {}".format(len(data)))
+
+def unpickle_object(data):
+    log_internal.debug("Unpickle byte string of length: {}".format(len(data)))
     return pickle.loads(data)
 
 
 _attachment_handlers = collections.OrderedDict()
 def registerAttachmentType(type_,
-        serialize_func=doPickle,
-        deserialize_func=doUnpickle,
-        content_type='application/octet-stream', gzip=True):
+                           serialize_func=pickle_object,
+                           deserialize_func=unpickle_object,
+                           content_type='application/octet-stream', gzip=True):
     """
     @type  type_: type
     @param type_: Instances of this type will be stored as attachments instead of CouchDB documents.
@@ -1502,7 +1565,7 @@ def registerAttachmentType(type_,
             'application/octet-stream')
     """
     if gzip:
-        handler_tuple = (lambda data: doGzip(serialize_func(data)), lambda data: deserialize_func(doGunzip(data)), content_type)
+        handler_tuple = (lambda data: gzip_compress(serialize_func(data)), lambda data: deserialize_func(gzip_decompress(data)), content_type)
     else:
         handler_tuple = (serialize_func, deserialize_func, content_type)
 
@@ -1533,7 +1596,7 @@ class CouchableAttachment(object):
         @rtype: byte string
         @return: The serialized data.
         """
-        return pickle.dumps(obj, pickle.HIGHEST_PROTOCOL)
+        return pickle_object(obj)
 
     @staticmethod
     def unpack(data):
@@ -1547,7 +1610,7 @@ class CouchableAttachment(object):
         @rtype: object
         @return: The unserialized object.
         """
-        return pickle.loads(data)
+        return unpickle_object(data)
 
 registerAttachmentType(CouchableAttachment,
         lambda obj: CouchableAttachment.pack(obj),
@@ -1580,22 +1643,23 @@ def findBadJson(obj, prefix=''):
             bad_list.extend(findBadJson(v, '{}[{}]'.format(prefix, i)))
     elif isinstance(obj, dict):
         for k, v in obj.items():
-            if isinstance(k, (str, int, float)):
+            if isinstance(k, string_types + integer_types + (float,)):
                 bad_list.extend(findBadJson(v, '{}[{!r}]'.format(prefix, k)))
             else:
                 bad_list.append('{} key {}'.format(prefix, k))
     elif isinstance(obj, float):
         if math.isnan(obj) or math.isinf(obj):
             bad_list.append('{} value {}, {}'.format(prefix, obj, type(obj)))
-    elif isinstance(obj, str):
+    elif isinstance(obj, bytes):
+        # By JSON standard there should only be unicode strings, but we keep this check
         try:
-            obj.encode('ascii')
-        except:
-            bad_list.append('{} not ascii {}, {}'.format(prefix, obj, type(obj)))
-    elif isinstance(obj, (int, unicode)):
+            obj.decode("UTF-8")
+        except UnicodeDecodeError:
+            bad_list.append('{} not UTF-8 {}, {}'.format(prefix, obj, type(obj)))
+    elif isinstance(obj, string_types + integer_types):
         pass
     else:
-        bad_list.append('{} type {}, {}'.format(prefix, obj, type(obj)))
+        bad_list.append('{} unexpected type {}, {}'.format(prefix, obj, type(obj)))
 
     return bad_list
 

--- a/couchable/core.py
+++ b/couchable/core.py
@@ -493,10 +493,10 @@ class CouchableDb(object):
             # Make sure all post request components are bytes
             db_url = self.db.resource.url
             if isinstance(db_url, unicode):
-                db_url = db_url.encode("UTF-8")
+                db_url = db_url.encode('UTF-8')
             doc_id = doc['_id']
             if isinstance(doc_id, unicode):
-                doc_id = doc_id.encode("UTF-8")
+                doc_id = doc_id.encode('UTF-8')
             http_headers = {b'Referer': db_url, b'Content-Type': header_str[len('Content-Type: '):]}
             status, msg, data = self.db.resource.post(doc_id, body, http_headers)
 
@@ -816,7 +816,7 @@ class CouchableDb(object):
                 pickle_binary = True
             else:
                 try:
-                    data = data.decode("UTF-8")
+                    data = data.decode('UTF-8')
                 except UnicodeDecodeError:
                     log_internal.warning("Could not decode binary string, pickle object")
                     pickle_binary = True
@@ -1078,7 +1078,7 @@ class CouchableDb(object):
         try:
             if isinstance(doc, bytes):
                 # JSON Documents should be unicode encoded by standard
-                doc = doc.decode("UTF-8")
+                doc = doc.decode('UTF-8')
             if isinstance(doc, string_types):
                 if doc.startswith(FIELD_NAME):
                     _, method_str, data = doc.split(':', 2)
@@ -1101,9 +1101,9 @@ class CouchableDb(object):
 
                     type_str, data = data.split(':', 1)
                     if method_str == 'append':
-                        if type_str in ('unicode', "str"):
+                        if type_str in ('unicode', 'str'):
                             if isinstance(data, bytes):
-                                return data.decode("UTF-8")
+                                return data.decode('UTF-8')
                             else:
                                 return data
 
@@ -1482,9 +1482,9 @@ def doGzip(data, compresslevel=1):
     """
     if not isinstance(data, bytes):
         if sys.version_info.major < 3:
-            data = str(data).encode("UTF-8")
+            data = str(data).encode('UTF-8')
         else:
-            data = str(data, "UTF-8")
+            data = str(data, 'UTF-8')
     log_internal.debug("Compress byte string with length: {}".format(len(data)))
 
     buffer = io.BytesIO()
@@ -1665,7 +1665,7 @@ def findBadJson(obj, prefix=''):
     elif isinstance(obj, bytes):
         # By JSON standard there should only be unicode strings, but we keep this check
         try:
-            obj.decode("UTF-8")
+            obj.decode('UTF-8')
         except UnicodeDecodeError:
             bad_list.append('{} not UTF-8 {}, {}'.format(prefix, obj, type(obj)))
     elif isinstance(obj, string_types + integer_types):

--- a/couchable/testing/test_couchable.py
+++ b/couchable/testing/test_couchable.py
@@ -18,15 +18,15 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
+# Future compatibility
+from __future__ import division, absolute_import, print_function, unicode_literals
 
 # stdlib
 import collections
 import copy
-import cPickle as pickle
 import datetime
 import doctest
 import gc
-import random
 import re
 import sys
 import time
@@ -40,6 +40,12 @@ from nose.plugins.attrib import attr
 # in-house
 import couchable
 import couchable.core
+
+# Compatibility imports
+if sys.version_info.major < 3:
+    import cPickle as pickle
+else:
+    import pickle
 
 #def dumpcdb(func):
 #    def test_dumpcdb_(self):
@@ -242,7 +248,7 @@ class TestCouchable(unittest.TestCase):
         cdb_list = [couchable.CouchableDb('testing_couchable_' + str(i)) for i in range(n)]
         t1 = time.time()
 
-        print 'first', t1-t0
+        print('first', t1-t0)
 
         for cdb in cdb_list:
             del couchdb.Server(cdb.server_url)[cdb.name]
@@ -254,7 +260,7 @@ class TestCouchable(unittest.TestCase):
         cdb_list = [couchable.CouchableDb('testing_couchable_' + str(i)) for i in range(n)]
         t1 = time.time()
 
-        print 'create', t1-t0
+        print('create', t1-t0)
 
         cdb_list = []
         gc.collect()
@@ -263,13 +269,13 @@ class TestCouchable(unittest.TestCase):
         cdb_list = [couchable.CouchableDb('testing_couchable_' + str(i)) for i in range(n)]
         t1 = time.time()
 
-        print 'exists', t1-t0
+        print('exists', t1-t0)
 
         t0 = time.time()
         cdb_list = [couchable.CouchableDb('testing_couchable_' + str(i), exists=True) for i in range(n)]
         t1 = time.time()
 
-        print 'exists w/ flag', t1-t0
+        print('exists w/ flag', t1-t0)
 
         for cdb in cdb_list:
             del couchdb.Server(cdb.server_url)[cdb.name]
@@ -947,7 +953,7 @@ class TestCouchable(unittest.TestCase):
         c = SimpleDoc(name='CCC', attach=SimpleAttachment(c=1, cc=2), bb=b)
         a = SimpleDoc(name='AAA', attach=SimpleAttachment(a=1, aa=2), bb=b,
                 dt=datetime.datetime.now(),
-                td=datetime.timedelta(seconds=1.5),
+                td=datetime.timedelta(seconds=2.5),
                 regex=re.compile('[a-z]+'),
             )
 
@@ -992,7 +998,7 @@ class TestCouchable(unittest.TestCase):
         c = AftermarketDoc(name='CCC', attach=AftermarketAttachment(c=1, cc=2), bb=b)
         a = AftermarketDoc(name='AAA', attach=AftermarketAttachment(a=1, aa=2), bb=b,
                 dt=datetime.datetime.now(),
-                td=datetime.timedelta(seconds=1.5),
+                td=datetime.timedelta(seconds=2.5),
                 regex=re.compile('[a-z]+'),
             )
 

--- a/couchable/testing/test_couchable.py
+++ b/couchable/testing/test_couchable.py
@@ -46,6 +46,8 @@ if sys.version_info.major < 3:
     import cPickle as pickle
 else:
     import pickle
+# Print python version for test log
+print(sys.version)
 
 #def dumpcdb(func):
 #    def test_dumpcdb_(self):

--- a/couchable/testing/test_couchable.py
+++ b/couchable/testing/test_couchable.py
@@ -293,7 +293,6 @@ class TestCouchable(unittest.TestCase):
         gc.collect()
         self.assertFalse(self.cdb._obj_by_id, repr(self.cdb._obj_by_id.items()))
 
-
         obj = self.cdb.load(_id)
 
         self.assertEqual(obj.__class__, Simple)
@@ -382,7 +381,7 @@ class TestCouchable(unittest.TestCase):
 
     @attr('couchable')
     def test_21_binaryStrings_1(self):
-        s = 'abc\xaa\xbb\xcc this is the tricky part: \\xddd'
+        s = b'abc\xaa\xbb\xcc this is the tricky part: \\xddd'
         obj = Simple(s=s)
 
         _id = self.cdb.store(obj)
@@ -399,7 +398,7 @@ class TestCouchable(unittest.TestCase):
     @attr('couchable')
     def test_21_binaryStrings_2(self):
         #s = 'abc\xaa\xbb\xcc this is the tricky part: \\xddd'
-        s = ''.join([chr(x) for x in range(256)])
+        s = bytes(tuple(x for x in range(256)))
         obj = Simple(s=s)
 
         _id = self.cdb.store(obj)

--- a/setup.py
+++ b/setup.py
@@ -23,14 +23,14 @@ from setuptools import setup
 
 setup(
     name='couchable',
-    version='0.5.1',
+    version='1.0.0beta1',
     author='Eli Stevens',
     author_email='wickedgrey@gmail.com',
     url='http://github.com/wickedgrey/couchable',
     description='Allows arbitrary python objects to be stored in CouchDB, while keeping the resulting CouchDB document as "natural" as possible.',
     packages=['couchable',],
     install_requires=[
-            'CouchDb >= 0.8',
+            'CouchDb >= 1.2',
             'requests',
         ],
     classifiers=[


### PR DESCRIPTION
# Python 2/3 compatible port of couchable

## Description

This is a functional port of the couchable python package to Python3 with existing Python2 support (not tested for earlier versions than Python2.7.X)

This is a minimal edit, there is still a lot I would like to improve if there would be time to do it. Some of the things are:

- Many dead comments/out-commented code
- Add meaningful custom exceptions instead of using standard Exception objects
- Test coverage is only mediocre
- Docstrings can be improved
- Older syntax could be exchanged with more modern (and more readable) Python syntax

Some of this is a bit ugly due to the compatibility layer of Python2/3, but I tried to make use of one large import statement that aliases a couple of things, which should allow for cleaning it properly up once the port is complete.

Strings are handled as unicode whenever possible and are UTF-8 encoded, whenever possible. 
This requires the package CouchDB to be at least at 1.2 (which at this point support Python2/3)
A full test run in the current environment is under way, couchables own test results are here:
[nose_python_2.7.15+.txt](https://github.com/mobius-medical/couchable/files/4117091/nose_python_2.7.15%2B.txt)
[nose_python_3.6.9.txt](https://github.com/mobius-medical/couchable/files/4117092/nose_python_3.6.9.txt)
[nose_python_3.7.5.txt](https://github.com/mobius-medical/couchable/files/4117089/nose_python_3.7.5.txt)
[nose_python_3.8.0.txt](https://github.com/mobius-medical/couchable/files/4117090/nose_python_3.8.0.txt)

Python2.7.15+ fails three tests, simply because getting doctests to properly work for Python2/3 unicode/str issues is a nightmare and there is no clean or good solution.

I added a couple of comments, where I believe an annotation would be useful for reviewing this PR, but where I did not want to include a comment in the code.

## Mobius main Pull Request:

https://github.com/mobius-medical/dev/pull/2484

## Test results

cdose2: http://10.4.194.27:8080/job/m3d-build-virtualenvs-cdose2/1136/
customer-collect: http://10.4.194.27:8080/job/m3d-test-customer-collect/546/testReport/
customer-collect rebuild: http://10.4.194.27:8080/job/m3d-test-customer-collect/547/
m3d-unit: http://10.4.194.27:8080/job/master-m3d-test-unit/469/
mmscompute-unit: http://10.4.194.27:8080/job/master-m3d-test-unit-mmscompute/136/
mmsutil-unit: http://10.4.194.27:8080/job/master-m3d-test-unit-mmsutil/88/
deploy: http://10.4.194.27:8080/job/m3d-test-deploy-neo/1028/